### PR TITLE
Change layoutParam class to avoid cast error

### DIFF
--- a/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
+++ b/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
@@ -25,6 +25,7 @@ public class AppBarLayoutManager extends ViewGroupManager<AppBarLayoutView>
 
     public static final int COMMAND_SHOW = 1;
     public static final int COMMAND_HIDE = 2;
+    public static final int COMMAND_REDRAW = 3;
 
     @Override
     public String getName() {
@@ -86,7 +87,8 @@ public class AppBarLayoutManager extends ViewGroupManager<AppBarLayoutView>
     Map<String, Integer> getCommandsMap() {
         return MapBuilder.of(
                 "show", COMMAND_SHOW,
-                "hide", COMMAND_HIDE
+                "hide", COMMAND_HIDE,
+                "redraw", COMMAND_REDRAW
         );
     }
 
@@ -98,6 +100,9 @@ public class AppBarLayoutManager extends ViewGroupManager<AppBarLayoutView>
                 break;
             case COMMAND_HIDE:
                 root.setExpanded(false, true);
+                break;
+            case COMMAND_REDRAW:
+                root.requestLayout();
                 break;
         }
     }

--- a/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
+++ b/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
@@ -2,6 +2,7 @@ package com.rncollapsingtoolbar;
 
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
+import android.view.ViewGroup;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
@@ -35,7 +36,7 @@ public class AppBarLayoutManager extends ViewGroupManager<AppBarLayoutView>
 
     @ReactProp(name = "height")
     public void setHeight(AppBarLayoutView view, int height) {
-        AppBarLayout.LayoutParams params = (AppBarLayout.LayoutParams) view.getLayoutParams();
+        ViewGroup.LayoutParams params = view.getLayoutParams();
         params.height = (int) PixelUtil.toPixelFromDIP(height);
         view.setLayoutParams(params);
     }

--- a/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
+++ b/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
@@ -6,6 +6,7 @@ import android.view.ViewGroup;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
@@ -21,6 +22,9 @@ public class AppBarLayoutManager extends ViewGroupManager<AppBarLayoutView>
     implements AppBarLayout.OnOffsetChangedListener  {
 
     private final static String REACT_CLASS = "CTLAppBarLayout";
+
+    public static final int COMMAND_SHOW = 1;
+    public static final int COMMAND_HIDE = 2;
 
     @Override
     public String getName() {
@@ -75,5 +79,26 @@ public class AppBarLayoutManager extends ViewGroupManager<AppBarLayoutView>
         event.putDouble("offset", verticalOffset);
         ReactContext reactContext = (ReactContext) appBarLayout.getContext();
         reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(appBarLayout.getId(), "topOffsetChanged", event);
+    }
+
+    @Override
+    public @javax.annotation.Nullable
+    Map<String, Integer> getCommandsMap() {
+        return MapBuilder.of(
+                "show", COMMAND_SHOW,
+                "hide", COMMAND_HIDE
+        );
+    }
+
+    @Override
+    public void receiveCommand(AppBarLayoutView root, int commandId, @javax.annotation.Nullable ReadableArray args) {
+        switch (commandId) {
+            case COMMAND_SHOW:
+                root.setExpanded(true, true);
+                break;
+            case COMMAND_HIDE:
+                root.setExpanded(false, true);
+                break;
+        }
     }
 }

--- a/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
+++ b/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutManager.java
@@ -40,7 +40,7 @@ public class AppBarLayoutManager extends ViewGroupManager<AppBarLayoutView>
     }
 
     @ReactProp(name = "height")
-    public void setHeight(AppBarLayoutView view, int height) {
+    public void setHeight(AppBarLayoutView view, double height) {
         ViewGroup.LayoutParams params = view.getLayoutParams();
         params.height = (int) PixelUtil.toPixelFromDIP(height);
         view.setLayoutParams(params);

--- a/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutView.java
+++ b/android/src/main/java/com/rncollapsingtoolbar/AppBarLayoutView.java
@@ -3,6 +3,7 @@ package com.rncollapsingtoolbar;
 import android.content.Context;
 import android.support.design.widget.AppBarLayout;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 
 public class AppBarLayoutView extends AppBarLayout {
     public AppBarLayoutView(Context context) {
@@ -15,4 +16,30 @@ public class AppBarLayoutView extends AppBarLayout {
 
         this.setLayoutParams(params);
     }
+
+    @Override
+    public void requestLayout() {
+        super.requestLayout();
+        post(measureAndLayout);
+
+        // Notify to parent CoordinatorLayoutView to update if exist
+        ViewParent parentView = this.getParent();
+        while (parentView != null) {
+            if (parentView instanceof CoordinatorLayoutView) {
+                parentView.requestLayout();
+                break;
+            }
+            parentView = parentView.getParent();
+        }
+    }
+
+    private final Runnable measureAndLayout = new Runnable() {
+        @Override
+        public void run() {
+            measure(
+                    MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+            layout(getLeft(), getTop(), getRight(), getBottom());
+        }
+    };
 }

--- a/android/src/main/java/com/rncollapsingtoolbar/CoordinatorLayoutView.java
+++ b/android/src/main/java/com/rncollapsingtoolbar/CoordinatorLayoutView.java
@@ -18,4 +18,20 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
         this.setLayoutParams(params);
         this.setFitsSystemWindows(false);
     }
+
+    @Override
+    public void requestLayout() {
+        super.requestLayout();
+        post(measureAndLayout);
+    }
+
+    private final Runnable measureAndLayout = new Runnable() {
+        @Override
+        public void run() {
+            measure(
+                    MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+            layout(getLeft(), getTop(), getRight(), getBottom());
+        }
+    };
 }

--- a/lib/AppBarLayout.js
+++ b/lib/AppBarLayout.js
@@ -44,6 +44,14 @@ class AppBarLayout extends Component {
     );
   };
 
+  redraw = () => {
+    UIManager.dispatchViewManagerCommand(
+      this.getViewHandle(),
+      UIManager.CTLAppBarLayout.Commands.redraw,
+      null
+    );
+  };
+
   getViewHandle = () => {
     return findNodeHandle(this.appBarLayout);
   };

--- a/lib/AppBarLayout.js
+++ b/lib/AppBarLayout.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import {
   UIManager,
+  findNodeHandle,
   StyleSheet,
   ViewPropTypes,
   requireNativeComponent,
@@ -27,10 +28,31 @@ class AppBarLayout extends Component {
     onOffsetChanged && onOffsetChanged(e)
   }
 
+  show = () => {
+    UIManager.dispatchViewManagerCommand(
+      this.getViewHandle(),
+      UIManager.CTLAppBarLayout.Commands.show,
+      null
+    );
+  };
+
+  hide = () => {
+    UIManager.dispatchViewManagerCommand(
+      this.getViewHandle(),
+      UIManager.CTLAppBarLayout.Commands.hide,
+      null
+    );
+  };
+
+  getViewHandle = () => {
+    return findNodeHandle(this.appBarLayout);
+  };
+
   render() {
     return (
       <CTLAppBarLayout
         {...this.props}
+        ref={ref => this.appBarLayout = ref}
         onOffsetChanged={this.handleOffsetChanged}
       />
     )


### PR DESCRIPTION
I think using `ViewGroup.LayoutParams` class is safer as we don't need to use any special methods of `AppBarLayout.LayoutParams` in this case.