### PR TITLE
Use project wide build versions if available

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,5 @@ def safeExtGet(prop, fallback) {
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
-    compile 'com.android.support:design:${safeExtGet('supportLibVersion', '26.1.0')}"
+    compile "com.android.support:design:${safeExtGet('supportLibVersion', '26.1.0')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,8 +30,12 @@ allprojects {
     }
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
+    compile "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
+    compile 'com.android.support:design:${safeExtGet('supportLibVersion', '26.1.0')}"
 }


### PR DESCRIPTION
Replace the hardcoded support library versions with configured versions if project wide settings are given by the host project.

Fixes #22 